### PR TITLE
Add license info to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "dist/fullcalendar.js",
     "dist/fullcalendar.css"
   ],
+  "license": "MIT",
   "ignore": [
     "*",
     "**/.*",


### PR DESCRIPTION
I was trying to add this package as a bower webjar (http://www.webjars.org). Webjar requires license information to be added in bower.json to properly deploy package.
